### PR TITLE
feat: bring `node-fetch` back but with `node-fetch-native`

### DIFF
--- a/lib/bili.js
+++ b/lib/bili.js
@@ -1,4 +1,5 @@
 const { cardTemplate } = require('./template')
+const { fetch } = require('node-fetch-native')
 
 const convert = (num) => (num >= 1E4) ? (num / 1E4).toFixed(1) + "万" : (num)
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "MaxChang3",
   "license": "MIT",
   "dependencies": {
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "node-fetch-native": "^1.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,16 @@ dependencies:
   lodash.get:
     specifier: ^4.4.2
     version: 4.4.2
+  node-fetch-native:
+    specifier: ^1.4.0
+    version: 1.4.0
 
 packages:
 
   /lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    dev: false
+
+  /node-fetch-native@1.4.0:
+    resolution: {integrity: sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==}
     dev: false


### PR DESCRIPTION
在之前的版本中考虑到目前 node.js 主流版本已经到了 18+ 就移除了 `node-fetch`。但是仍有 （#9）一部分低版本的 node.js 用户在使用 hexo，考虑到这个问题，选择了更优雅的 `node-fetch-native` 来防止高版本 node.js 额外引入 `node-fetch`。